### PR TITLE
feat(ci): replace manual gemini api call with run-gemini-cli action

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -27,30 +27,12 @@ jobs:
 
       - name: Call Gemini API for Review
         id: gemini_review
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          DIFF: ${{ steps.get_diff.outputs.diff }}
-        run: |
-          PROMPT_TEMPLATE=$(cat .github/workflows/pr-review.prompt)
-          PROMPT="$PROMPT_TEMPLATE\n\n**Git Diff to review:**\n$DIFF"
-
-          API_URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=$GEMINI_API_KEY"
-          
-          JSON_PAYLOAD=$(jq -n --arg prompt "$PROMPT" '{ "contents": [ { "parts": [ { "text": $prompt } ] } ] }')
-
-          RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" -d "$JSON_PAYLOAD" "$API_URL")
-          
-          if echo "$RESPONSE" | jq -e '.error' > /dev/null; then
-            echo "Error from Gemini API:"
-            echo "$RESPONSE" | jq '.error'
-            exit 1
-          fi
-
-          REVIEW_COMMENT=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text')
-          
-          echo "comment<<EOF" >> $GITHUB_OUTPUT
-          echo "$REVIEW_COMMENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+        uses: neondatabase/run-gemini-cli@v1
+        with:
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          prompt: |
+            ${{ steps.get_diff.outputs.diff }}
+          prompt-file: .github/workflows/pr-review.prompt
 
       - name: Post Review Comment
         uses: marocchino/sticky-pull-request-comment@v2
@@ -59,4 +41,4 @@ jobs:
           message: |
             ### ✨ AI Review ✨
             
-            ${{ steps.gemini_review.outputs.comment }}
+            ${{ steps.gemini_review.outputs.gemini-response }}


### PR DESCRIPTION
Replaced the manual `curl` command with the `run-gemini-cli` GitHub Action in the PR review workflow.

This change simplifies the workflow file and makes it easier to maintain. It also leverages a dedicated action for interacting with the Gemini API, which can provide better error handling and a more streamlined experience.